### PR TITLE
Add support for secure POST_URL

### DIFF
--- a/analyser/daemon.rb
+++ b/analyser/daemon.rb
@@ -53,7 +53,7 @@ loop do
     response = nil
 
     begin
-      response = Net::HTTP.start(uri.host, uri.port) do |http|
+      response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
         http.request request
       end
       KartLog.info "Sending #{events.length} event(s). Response #{response.body}"

--- a/players/lib/scan.rb
+++ b/players/lib/scan.rb
@@ -52,13 +52,14 @@ def submit(players)
     }
 
   uri = URI.parse(ENV['POST_URL'])
-  header = {'Content-Type': 'application/json'}
 
-  http = Net::HTTP.new(uri.host, uri.port)
-  request = Net::HTTP::Post.new(uri.request_uri, header)
+  request = Net::HTTP::Post.new(uri.path)
+  request.content_type = 'application/json'
   request.body = payload.to_json
 
-  response = http.request(request)
+  response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
+    http.request request
+  end
 
   unless response.code == '200'
     puts response.message


### PR DESCRIPTION
Allow daemon & player scan to work with https urls by setting `use_ssl` when the scheme is `https`.