### PR TITLE
Allow configurable temp dir so a ramdisk can be used.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -82,6 +82,22 @@ Notice that the `match_result_screen` gets possibly incomplete data - animations
 
 For debugging purposes you can also set `KEEP_FILES=true` - this will instuct the daemon not to remove processed files.
 
+Due to limitations of the phasion API, analysis requires a lot of
+writing/reading temporary files to disk. Using a ramdisk as a temporary
+directory may improve performance by 10% or more!
+
+To measure the difference in isolation:
+
+```
+ruby bench/identification.rb
+
+# linux
+sudo mkdir /mnt/tmp
+sudo mount -t tmpfs -o size=2m tmpfs /mnt/tmp
+
+TMPDIR=/mnt/tmp ruby bench/identification.rb
+```
+
 ### phashion
 
 You may experience issues when bundling / installing the phashion gem. Thanks to [ElliotCui over on Stack Overflow](https://stackoverflow.com/a/66494254) for figuring out a solution.

--- a/analyser/.gitignore
+++ b/analyser/.gitignore
@@ -1,1 +1,3 @@
 intro/*
+calls.html
+graph.html

--- a/analyser/Gemfile
+++ b/analyser/Gemfile
@@ -6,3 +6,8 @@ gem 'phashion'
 gem 'activesupport'
 
 gem 'rspec'
+
+group :benchmark do
+  gem 'enumerable-statistics'
+  gem 'ruby-prof'
+end

--- a/analyser/Gemfile.lock
+++ b/analyser/Gemfile.lock
@@ -10,6 +10,7 @@ GEM
     coderay (1.1.2)
     concurrent-ruby (1.1.6)
     diff-lcs (1.3)
+    enumerable-statistics (2.0.7)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     method_source (0.9.2)
@@ -32,6 +33,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.0)
+    ruby-prof (1.4.3)
     thread_safe (0.3.6)
     tzinfo (1.2.10)
       thread_safe (~> 0.1)
@@ -42,10 +44,12 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport
+  enumerable-statistics
   phashion
   pry
   rmagick
   rspec
+  ruby-prof
 
 BUNDLED WITH
-   2.0.2
+   2.2.15

--- a/analyser/bench/identification.rb
+++ b/analyser/bench/identification.rb
@@ -1,0 +1,35 @@
+$LOAD_PATH.unshift File.join(File.dirname(__FILE__), "..")
+
+require 'analyser'
+require 'enumerable/statistics'
+require 'ruby-prof'
+
+times = []
+prof = false
+
+RubyProf.start if prof
+# in race test screen
+test_image = "2017062619484500-16851BE00BC6068871FE49D98876D6C5.jpg"
+40.times do
+  Dir["training-data/#{test_image}"].each do |f|
+  # Dir["training-data/*.jpg"].each do |f|
+    start_time = Time.now
+    Analyser.analyse!(f)
+    end_time = Time.now
+    times.push(end_time - start_time)
+  end
+end
+if prof
+  result = RubyProf.stop
+  printer = RubyProf::GraphHtmlPrinter.new(result)
+  File.open("graph.html", "w") {|f| printer.print(f) }
+
+  printer = RubyProf::CallStackPrinter.new(result)
+  File.open("calls.html", "w") {|f| printer.print(f) }
+end
+
+puts "Count:   #{times.length}"
+puts "Total:   #{times.sum}"
+puts "Median:  #{times.median}"
+puts "Mean:    #{times.mean}"
+puts "Max:     #{times.max}"

--- a/analyser/screens/screen.rb
+++ b/analyser/screens/screen.rb
@@ -1,7 +1,8 @@
 class Screen
+  TMPDIR = ENV.fetch("TMPDIR", "dump")
   def self.convert_to_phash(image)
-    image.write('dump/tmp.jpg')
+    image.write("#{TMPDIR}/tmp.jpg")
     image.destroy!
-    Phashion::Image.new('dump/tmp.jpg')
+    Phashion::Image.new("#{TMPDIR}/tmp.jpg")
   end
 end


### PR DESCRIPTION
On my ubuntu VM, this resulted in about a ~10-15% improvement on the
race screen (the most intensive):

    # BEFORE
    > ruby bench/identification.rb
    Count:   40
    Total:   0.782132122
    Median:  0.0186125905
    Mean:    0.01955330305
    Max:     0.047720616

    # AFTER
    > TMPDIR=/mnt/tmp ruby bench/identification.rb
    Count:   40
    Total:   0.678847727
    Median:  0.0159653975
    Mean:    0.016971193175
    Max:     0.046282758

Dunno if this will help on the mini though, or if we've already configured it like this.

I'm not seeing a lot of other low hanging fruit for optimisation, the bulk of the time is spent in phash.

Thoughts for future work:

* What are our actual observed processing rates? Can we hook them up to prometheus or something? From the above benchmarking my machine appears like it could comfortably run at 10-20fps inside a VM...
* This task is obviously parrallizeble, so should be able to take advantage of threads. That's tricky with ruby though coz of the GIL, maybe ruby 3 gives us some stuff here? Or rewrite in rust - seems overkill?
* Review matching algorithms. There's a lot of iteration that has to happen, possibly some opportunities to rethink algos but nothing obvious jumped out at me.
* Why are we using a mini again? Is it just coz that's what we had lying around, or is there a deeper reason?