### PR TITLE
Add overmind + startup scripts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# KEEP_FILES=set
+SKIP_DEV_DATA=set
+POST_URL=http://localhost:3000/api/kartalytics/ingest
+CAPTURE_CARD_NAME="USB Video"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dump/*.jpg
 analyser.log
 tmp.jpg
 .DS_Store
+.env

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,2 @@
+brew "overmind"
+brew "tmux"

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,5 @@
+brain: script/brain
+ffmpeg: script/ffmpeg
+watcher: script/ffmpeg_watcher
+analyser: script/analyser
+players: script/players

--- a/Readme.md
+++ b/Readme.md
@@ -38,7 +38,21 @@ Its function is to capture the input stream of Mario Kart and save it out as seq
 
 ### Running
 
-To setup the recorder:
+#### HDMI Capture Card
+
+These devices can be found for quite cheap, so this is now the recommended way of capturing screenshots from the Switch. You'll find a script for this in `script/ffmpeg`, but you'll likely need to tweak the settings for your specific capture card.
+
+In our case, we capture at 1080p and downscale to 720p with FFmpeg, because capturing at 720p results in _worse_ performance. We also need to set the RGB range on the Switch to limited to avoid clipping.
+
+More information about these cards can be found on [Yoon's Blog](https://www.naut.ca/blog/2020/07/09/cheap-hdmi-capture-card-review/).
+
+```sh
+cd analyser/dump && ffmpeg -skip_frame nokey -f avfoundation -r 10 -video_size 1920x1080 -pix_fmt nv12 -color_range 1 -i "USB Video" -vf scale=-1:720 -r 5 -qscale:v 5 out%04d.jpg
+```
+
+#### Lenkeng LKV373A V3.0
+
+The Lenkeng LKV373A V3.0 is the original way capture images from the Switch. The V3.0 has been superseded by V4.0, which doesn't work as well for this application. However, if you happen to get your hands on one, here's how to set it up:
 
   1. Install ffmpeg
   2. Thanks to [Danman](https://blog.danman.eu/new-version-of-lenkeng-hdmi-over-ip-extender-lkv373a/) you need to block 0 byte UDP packets that the encoder spits out - use this command: `sudo iptables -t raw -A PREROUTING -p udp -m length --length 28 -j DROP`

--- a/Readme.md
+++ b/Readme.md
@@ -19,6 +19,16 @@ It is comprised of 3 main parts:
 
 Kartalytics is designed to handle only 3 and 4 player VS matches at 200cc (what we play competitively).
 
+## Quickstart
+
+Set up your env, bootstrap, and start. This will boot all necessary services. For more information about each service, keep reading.
+
+```sh
+cp .env.example .env
+./script/bootstrap
+./script/start
+```
+
 ## Recorder
 
 Its function is to capture the input stream of Mario Kart and save it out as sequence of snapshots. To do this we'll use the following hardware:

--- a/players/script/bootstrap
+++ b/players/script/bootstrap
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+echo "--- [script:bootstrap]"
+
+brew bundle
+bundle

--- a/script/analyser
+++ b/script/analyser
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+echo "Running analyser..."
+cd analyser
+
+ruby daemon.rb

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+brew bundle
+
+pushd analyser
+  ./script/bootstrap.sh
+popd
+
+pushd brain
+  ./script/bootstrap
+popd
+
+pushd players
+  ./script/bootstrap
+popd

--- a/script/brain
+++ b/script/brain
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+if [[ "$POST_URL" =~ "localhost" ]]; then
+  echo "Running brain..."
+  cd brain
+
+  bin/rails s
+else
+  echo "Remote POST_URL detected, skipping brain"
+fi

--- a/script/ffmpeg
+++ b/script/ffmpeg
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+echo "Running FFmpeg..."
+cd analyser/dump
+
+# LENKENG LKV373A
+# ffmpeg -i "udp://239.255.42.42:5004?localaddr=192.168.1.1&buffer_size=128000&overrun_nonfatal=1&fifo_size=500000" -vf fps=3 -qscale:v 5 out%04d.jpg
+
+# https://www.naut.ca/blog/2020/07/09/cheap-hdmi-capture-card-review/
+# RGB range on Switch must be set to Limited range
+# Adjust Screen Size on Switch must be set to 100%
+# input framerate must be set to 5 on Monterey
+ffmpeg \
+  -nostdin \
+  -loglevel error \
+  -skip_frame nokey \
+  -f avfoundation \
+  -r 10 \
+  -video_size 1920x1080 \
+  -pix_fmt nv12 \
+  -color_range 1 \
+  -i "$CAPTURE_CARD_NAME" \
+  -vf scale=-1:720 \
+  -r 5 \
+  -qscale:v 5 \
+  out%04d.jpg

--- a/script/ffmpeg_watcher
+++ b/script/ffmpeg_watcher
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+echo "Monitoring analyser log..."
+
+LOG_PATH="analyser/analyser.log"
+
+# if the capture card is disconnected, ffmpeg simply hangs. to autorecover from
+# this event, we watch the analyser log and restart ffmpeg if it hasn't
+# processed an image in the last 5 seconds.
+
+while : ; do
+  sleep 5
+
+  TIME="$(date +%s)"
+  MTIME="$(date -r "$LOG_PATH" +%s)"
+
+  if (( "$TIME" - "$MTIME" > 10 )); then
+    echo "FFmpeg appears to have hung. Restarting..."
+    overmind restart ffmpeg
+  fi
+done

--- a/script/players
+++ b/script/players
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+echo "Running players scan..."
+cd players
+
+ruby lib/scan.rb

--- a/script/start
+++ b/script/start
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# echo "Preparing Kartalytics..."
+# ./script/bootstrap
+
+rm -f .overmind.sock
+overmind start -c ffmpeg,brain


### PR DESCRIPTION
Kartalytics requires numerous services to be running concurrently. Currently these need to be booted manually, but this can be automated with Overmind meaning we now only need to run one script to start everything (`./script/start`). Also, having the scripts in the repo makes Kartalytics more portable.

Another benefit of Overmind is that it allows easy restarting of services. The `ffmpeg` script is a bit flakey because it a) requires the capture card to be present at boot, and b) hangs if the card is unplugged. We can watch for this (`ffmpeg_watcher`) and restart `ffmpeg` automatically, which avoids the need for manual recovery. Trying to do this purely in bash is extremely painful to say the least.

Finally, we also add some documentation for the HDMI capture card method.