### PR TITLE
Analyse match scores

### DIFF
--- a/analyser/screens/match_result_screen.rb
+++ b/analyser/screens/match_result_screen.rb
@@ -4,14 +4,38 @@ class MatchResultScreen < Screen
   REFERENCE_150 = Phashion::Image.new("reference_images/match_result/150.jpg")
   REFERENCE_200 = Phashion::Image.new("reference_images/match_result/200.jpg")
 
+  # where we may expect dark pixels in a 9-segment display
+  SEGMENTS = [
+    { x: 6, y: 1 },
+    { x: 2, y: 7 },
+    { x: 9, y: 7 },
+    { x: 16, y: 7 },
+    { x: 6, y: 14 },
+    { x: 2, y: 19 },
+    { x: 9, y: 19 },
+    { x: 16, y: 19 },
+    { x: 6, y: 25 },
+  ]
+
+  DIGITS = [
+    { digit: 0, segments: [1, 1, 0, 1, 0, 1, 0, 1, 1] },
+    { digit: 1, segments: [0, 0, 1, 0, 0, 0, 1, 0, 0] },
+    { digit: 2, segments: [1, 0, 0, 1, 1, 1, 0, 0, 1] },
+    { digit: 3, segments: [1, 0, 0, 1, 1, 0, 0, 1, 1] },
+    { digit: 4, segments: [0, 1, 0, 1, 1, 0, 0, 1, 0] },
+    { digit: 5, segments: [1, 1, 0, 0, 1, 0, 0, 1, 1] },
+    { digit: 6, segments: [1, 1, 0, 0, 1, 1, 0, 1, 1] },
+    { digit: 7, segments: [1, 0, 0, 1, 0, 0, 0, 1, 0] },
+    { digit: 8, segments: [1, 1, 0, 1, 1, 1, 0, 1, 1] },
+    { digit: 9, segments: [1, 1, 0, 1, 1, 0, 0, 1, 1] },
+  ]
+
   def self.matches_image?(screenshot)
     race_speed(screenshot) != nil
   end
 
   def self.extract_event(screenshot)
-    scoreboard = screenshot.working.get_pixels(103, 30, 1, 120)
-
-    player_positions = get_player_positions(scoreboard)
+    player_positions = get_player_positions(screenshot)
 
     unless player_positions.empty?
       {
@@ -21,7 +45,9 @@ class MatchResultScreen < Screen
     end
   end
 
-  def self.get_player_positions(scoreboard)
+  def self.get_player_positions(screenshot)
+    scoreboard = screenshot.working.get_pixels(103, 30, 1, 120)
+
     results = { }
 
     # We've got about 120px of scoreboard (146 actually)
@@ -43,7 +69,8 @@ class MatchResultScreen < Screen
     results.each do |player, possible_positions|
       position = possible_positions.select{ |position, likelihood| likelihood > 5 }.keys.first
       if position
-        results[player] = {position: position}
+        score = score_for(position, screenshot)
+        results[player] = { position: position, score: score }
       else
         results.delete(player)
       end
@@ -52,6 +79,25 @@ class MatchResultScreen < Screen
   end
 
   private
+
+  def self.score_for(position, screenshot)
+    offset_x, offset_y = 520, 94
+    col_width, row_height = 23, 42
+
+    # change below to 0..2 for > 6 races. this risks a phantom hundreds digit
+    # which could result in shockingly inaccurate scores (eg 999)
+    digits = (1..2).map do |col_index|
+      x = offset_x + col_index * col_width
+      y = offset_y + position * row_height
+      segments = SEGMENTS.map do |s|
+        pixel = screenshot.original.get_pixels(x + s[:x], y + s[:y], 1, 1).first
+        pixel.to_hsla[2] < 70 ? 1 : 0 # brightness
+      end
+      DIGITS.find { |d| d[:segments] == segments }&.fetch(:digit)
+    end
+
+    digits.compact.join.to_i
+  end
 
   def self.race_speed(screenshot)
     crop = screenshot.original.dup.crop!(37, 28, 99, 26)

--- a/analyser/screens/match_result_screen.rb
+++ b/analyser/screens/match_result_screen.rb
@@ -83,7 +83,7 @@ class MatchResultScreen < Screen
     end
 
     # Red
-    if (hue < 10 || hue > 340) && sat > 170 && lum > 150
+    if (hue < 10 || hue > 340) && sat > 160 && lum > 150
       return :player_three
     end
 

--- a/analyser/screens/race_result_screen.rb
+++ b/analyser/screens/race_result_screen.rb
@@ -104,7 +104,7 @@ class RaceResultScreen < Screen
     end
 
     # Red
-    if (hue < 10 || hue > 340) && sat > 170 && lum > 150
+    if (hue < 10 || hue > 340) && sat > 160 && lum > 150
       return :player_three
     end
 

--- a/analyser/spec/screens/match_result_screen_spec.rb
+++ b/analyser/spec/screens/match_result_screen_spec.rb
@@ -2,18 +2,36 @@ require 'spec_helper'
 
 describe MatchResultScreen do
   describe ".extract_event" do
-    let(:screenshot) { Screenshot.new(fixture('match-result.jpg')) }
+    context 'for 150cc' do
+      let(:screenshot) { Screenshot.new(fixture('match-result.jpg')) }
 
-    subject { described_class.extract_event(screenshot)[:data] }
+      subject { described_class.extract_event(screenshot)[:data] }
 
-    it 'should extract all player positions correctly' do
-      is_expected.to eq({
-        speed: '150cc',
-        player_one: {position: 8},
-        player_three: {position: 9},
-        player_two: {position: 11},
-        player_four: {position: 4}
-      })
+      it 'extracts all player positions and scores correctly' do
+        is_expected.to eq({
+          speed: '150cc',
+          player_one: { position: 8, score: 21 },
+          player_three: { position: 9, score: 21 },
+          player_two: { position: 11, score: 16 },
+          player_four: { position: 4, score: 23 },
+        })
+      end
+    end
+
+    context 'for 200cc' do
+      let(:screenshot) { Screenshot.new(fixture('match-result200cc.jpg')) }
+
+      subject { described_class.extract_event(screenshot)[:data] }
+
+      it 'extracts all player positions and scores correctly' do
+        is_expected.to eq({
+          speed: '200cc',
+          player_one: { position: 1, score: 68 },
+          player_three: { position: 2, score: 68 },
+          player_two: { position: 3, score: 64 },
+          player_four: { position: 4, score: 60 },
+        })
+      end
     end
   end
 


### PR DESCRIPTION
If a race results screen is missed, the final scores will be out of whack. This is a problem because we use the scores to order the players. 

To fix this, we can detect the scores on the match result screen, then the brain can decide to use its precomputed scores or the scores from the event.

Note: this may be flakey, will need more data to test.