### PR TITLE
Bump Chromedriver action

### DIFF
--- a/.github/workflows/brain.yml
+++ b/.github/workflows/brain.yml
@@ -69,7 +69,7 @@ jobs:
         uses: browser-actions/setup-chrome@latest
 
       - name: set up chromedriver
-        uses: nanasess/setup-chromedriver@v1
+        uses: nanasess/setup-chromedriver@v2
 
       - name: use node.js 16.x
         uses: actions/setup-node@master


### PR DESCRIPTION
Chromedriver has moved the endpoint to download versions, which is why there is a 404 in [other test runs](https://github.com/ferocia/kartalytics/actions/runs/8089780423/job/22106234520?pr=105#step:8:16).

https://github.com/nanasess/setup-chromedriver/issues/190
https://github.com/nanasess/setup-chromedriver/pull/192